### PR TITLE
Add type annotations to fib util function

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
The `fibonnaci` function in `fib.ts` contained type issues due not specifying the return type. This was fixed by making `number` the expected return in the function definition. The fix was tested by running `npm run lint`  and `npm run test`, both commands passed with no issues.