### PR TITLE
Add type annotations to express params in fibRoute.ts

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,9 @@
 // Endpoint for querying the fibonacci numbers
 
+import {Request, Response} from 'express';
 import fibonacci from "./fib";
 
-export default (req, res) => {
+export default (req: Request, res: Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
This PR addresses the issue in `fibRoute.ts` related to the `req` and `res` types. After adding the Express `Request` and `Response` types, `run npm lint` and `run npm test` both passed.